### PR TITLE
Add proper logger to consumer and handlers

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ Revision history for Perl extension PGXN::Manager
          output.
        - Configured handlers for INT, TERM, and QUIT signals to log flagging
          for shutdown in the next loop.
+       - Fixed invalid license example in the META spec.
+       - Added a logger to the Consumer and the Mastodon and Twitter handlers,
+         so that they now log debug and info messages about what's being sent.
 
 0.31.1   2023-10-07T21:40:53Z
        - Restored the writing of the pgxn_consumer PID file, accidentally

--- a/lib/PGXN/Manager/Maint.pm
+++ b/lib/PGXN/Manager/Maint.pm
@@ -8,7 +8,6 @@ use File::Spec;
 use File::Path qw(make_path remove_tree);
 use File::Basename qw(dirname basename);
 use Encode qw(encode_utf8);
-use Carp;
 use namespace::autoclean;
 
 our $VERSION = v0.31.2;
@@ -50,7 +49,7 @@ sub run {
     my ($self, $command) = (shift, shift);
     $command =~ s/-/_/g;
     my $meth = $self->can($command)
-        or croak qq{PGXN Maint: "$command" is not a command};
+        or die qq{PGXN Maint: "$command" is not a command};
     require PGXN::Manager;
     $self->$meth(@_);
 }

--- a/t/maint.t
+++ b/t/maint.t
@@ -111,7 +111,7 @@ RUN: {
     ok $maint->run('update-stats', 'now'), 'Run update-stats';
     is_deeply $params, ['now'], 'Should have called update_stats';
 
-    # Make sure we croak for an unknown command.
+    # Make sure we die for an unknown command.
     local $@;
     eval { $maint->run('nonexistent') };
     like $@, qr{PGXN Maint: "nonexistent" is not a command},

--- a/t/twitter.t
+++ b/t/twitter.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use utf8;
 
-use Test::More tests => 20;
+use Test::More tests => 31;
 # use Test::More 'no_plan';
 use JSON::XS;
 use Test::Exception;
@@ -13,8 +13,21 @@ use Test::MockModule;
 use lib 't/lib';
 use TxnTest;
 
+##############################################################################
+# Mock time.
+my (@gmtime, $time);
+BEGIN {
+    $time = CORE::time();
+    @gmtime = CORE::gmtime($time);
+    *CORE::GLOBAL::time = sub() { return $time };
+    *CORE::GLOBAL::gmtime = sub (;$) { return @gmtime }
+}
+
+##############################################################################
+# Load the class.
 BEGIN {
     use_ok 'PGXN::Manager' or die;
+    use_ok 'PGXN::Manager::Consumer' or die;
     use_ok 'PGXN::Manager::Consumer::twitter' or die;
 }
 
@@ -22,6 +35,33 @@ can_ok 'PGXN::Manager::Consumer::twitter', qw(
     new
     client
     handle
+);
+
+# Silence "used only once" warning by using CORE::GLOBAL::time.
+is CORE::GLOBAL::time(), time, 'Time should be mocked';
+
+# Grab the timestamp that will appear in logs.
+my $logtime = POSIX::strftime '%Y-%m-%dT%H:%M:%SZ', gmtime $time;
+is time, $time, 'Should have mocked time';
+is POSIX::strftime('%Y-%m-%dT%H:%M:%SZ', gmtime), $logtime,
+    'Should have mocked gmtime';
+
+##############################################################################
+# Mock log destination.
+my $log_output = '';
+my $log_fh = IO::File->new(\$log_output, 'w');
+$log_fh->binmode(':utf8');
+sub output {
+    my $ret = $log_output;
+    $log_fh->seek(0, 0);
+    $log_output = '';
+    return $ret // '';
+}
+
+# Set up a logger.
+my $logger = PGXN::Manager::Consumer::Log->new(
+    verbose => 1,
+    log_fh  => $log_fh,
 );
 
 open my $fh, '<:raw', 'conf/test.json' or die "Cannot open conf/test.json: $!\n";
@@ -37,19 +77,23 @@ while (@{ $conf->{consumers} } && $cfg->{type} ne 'twitter') {
 }
 die "No twitter config found in conf/test.json\n" unless $cfg;
 delete $cfg->{events};
-my $twitter = PGXN::Manager::Consumer::twitter->new( config => $cfg );
+my $twitter = PGXN::Manager::Consumer::twitter->new(
+    config => $cfg,
+    logger => $logger,
+);
 is $twitter->name, 'twitter', 'Should have name method';
 
 # Should get an exception for missing API config.
 CONFIG: {
     for my $key (qw(consumer_key consumer_secret access_token access_token_secret)) {
         my $val = delete $cfg->{$key};
-        throws_ok { PGXN::Manager::Consumer::twitter->new(config => $cfg) }
-            qr/Missing Twitter API $key/, "Should have no clent when no $key";
+        throws_ok { PGXN::Manager::Consumer::twitter->new(
+            config => $cfg,
+            logger => $logger,
+        ) } qr/Missing Twitter API $key/, "Should have no clent when no $key";
         $cfg->{$key} = $val;
     }
 }
-
 
 # Test tweeting.
 my $twitter_mock = Test::MockModule->new('Net::Twitter::Lite::WithAPIv1_1');
@@ -86,18 +130,40 @@ $twitter_mock->mock(update => sub {
     return $nt;
 });
 
-# Start with unkown event.
+# Start with unknown event.
+is output(), '', 'Should have no output so far';
 is $twitter->handle(nonesuch => $meta), undef,
     'Should send no message for unknown event';
+is output(), '', 'Should have no log for unknown event';
+
+# Try it with debug verbosity.
+$logger->{verbose} = 2;
+is $twitter->handle(nonesuch => $meta), undef,
+    'Should send no message for unknown event';
+is output(),
+    "$logtime - DEBUG: Twitter skiping nonesuch notification\n",
+    'Should have unknown event log message';
 
 # Send release event.
 ok $twitter->handle(release => $meta), 'Should send release message';
+is output(),
+    "$logtime - DEBUG: Fetching Twitter username for $meta->{user}\n" .
+    "$logtime - INFO: Posting \L$meta->{name}-$meta->{version}\E to Twitter\n",
+    'Should have DEBUG username lookup and INFO message for posting';
 
 # Look up the Twitter username in the database.
+$logger->{verbose} = 1;
 $meta->{user} = TxnTest->user;
 $tweet = "$meta->{name} $meta->{version} released by \@notHere: $url";
 ok $twitter->handle(release => $meta), 'Should send message with Twitter nick';
+is output(),
+    "$logtime - INFO: Posting \L$meta->{name}-$meta->{version}\E to Twitter\n",
+    'Should have INFO message for posting';
 
 # Have Twitter throw an exception.
-$twitter_mock->mock(update => sub { die 'WTF!' });
-throws_ok {$twitter->client->update('hi!') } qr/WTF!/, 'Fail to send a tweet';
+$twitter_mock->mock(update => sub { die "WTF!\n" });
+ok !$twitter->handle(release => $meta), 'Should not send message';
+is output(),
+    "$logtime - INFO: Posting \L$meta->{name}-$meta->{version}\E to Twitter\n" .
+    "$logtime - ERROR: Error posting \L$meta->{name}-$meta->{version}\E to Twitter: WTF!\n\n",
+    'Should have INFO message and ERROR message';


### PR DESCRIPTION
Create (hidden) package PGXN::API::Consumer::Log and set it up with log level as the first argument to its `log` method, and suppress logging according to verbosity. Teach Consumer to use it, then also teach the Mastodon and Twitter handlers. Add tests to ensure it all works, including time mocking in the Mastodon and Twitter tests.

Note that the handlers no longer throw an error on failure, but simply log it. The Consumer still wraps the handlers in `try`/`catch` in order to log any unexpected errors and continue runnnig.

This will mean additional log information from the handlers, in particular, which did no logging previously. Will be helpful when something happens to the consumer and we can see in the log what the last release to be processed was.

While at it, remove unnecessary uses of Carp.