### PR TITLE
Move PID deletion out of DEMOLISH method

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,10 @@ Revision history for Perl extension PGXN::Manager
        - Fixed invalid license example in the META spec.
        - Added a logger to the Consumer and the Mastodon and Twitter handlers,
          so that they now log debug and info messages about what's being sent.
+       - Moved PID file cleanup from the `DEMOLISH` method to the `run` method,
+         where it should always execute. This will hopefully fix the issue
+         where the consumer mysteriously ceases running and doesn't remove its
+         PID file, so never restarts.
 
 0.31.1   2023-10-07T21:40:53Z
        - Restored the writing of the pgxn_consumer PID file, accidentally

--- a/lib/PGXN/Manager/Consumer.pm
+++ b/lib/PGXN/Manager/Consumer.pm
@@ -89,13 +89,6 @@ sub _signal_handler {
     };
 }
 
-sub DEMOLISH {
-    my $self = shift;
-    if (my $path = $self->pid_file) {
-        unlink $path;
-    }
-}
-
 sub run {
     my $self = shift;
     $self->log(INFO => sprintf "Starting %s %s", __PACKAGE__, __PACKAGE__->VERSION);
@@ -112,6 +105,11 @@ sub run {
     while ($self->continue) {
         $self->consume($consumers_for);
         sleep($self->interval);
+    }
+
+    if (my $path = $self->pid_file) {
+        $self->log(DEBUG => "Unlinking PID file ", $self->pid_file);
+        unlink $path;
     }
 
     $self->log(INFO => 'Shutting down');


### PR DESCRIPTION
There is no guarantee from Perl that it's called in a timely manner or order when shutting down. The `pid_file` field may no longer be set. This might explain why the PID file was never cleaned up.

Move it instead to the `run` method, where it should always run once a signal handler has set `continue` to false. It exits the loop on the next run, then cleans up the PID file before exiting. At least that's the idea.

Move the PID test to the `run` test section of `t/consumer.t`, since `run` is where it happens now.