### PR TITLE
Remove deprecated given/when syntax

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,8 @@ Revision history for Perl extension PGXN::Manager
          where it should always execute. This will hopefully fix the issue
          where the consumer mysteriously ceases running and doesn't remove its
          PID file, so never restarts.
+       - Replaced use of the deprecated `given`/`when` syntax with plain old
+         `if`/`elsif`/`else`.
 
 0.31.1   2023-10-07T21:40:53Z
        - Restored the writing of the pgxn_consumer PID file, accidentally

--- a/lib/PGXN/Manager/Request.pm
+++ b/lib/PGXN/Manager/Request.pm
@@ -116,12 +116,12 @@ value in the `X-Forwarded-Script-Name` header and set the configuration to
 
 =head3 C<respond_with>
 
-  given ($req->respond_with) {
-      say '<h1>Hi</h1>'                    when 'html';
-      say 'Hi'                             when 'text';
-      say '<feed><title>hi</title></feed>' when 'atom';
-      say '{ "title": "hi" }'              when 'json';
-  }
+  my $type = $req->respond_with;
+  say   $type eq 'html' ? '<h1>Hi</h1>'
+      : $type eq 'text' ? 'Hi' 
+      : $type eq 'atom' ? '<feed><title>hi</title></feed>'
+      : $type eq 'json' ? '{ "title": "hi" }'
+      :                   die "Unknown type $type";
 
 This method uses L<HTTP::Negotiate> to select and return a preferred response
 type based on the request accept headers. It supports and can return one of


### PR DESCRIPTION
Was always experimental, been deprecated for a while, and for some reason the warnings jumped out at me today. So replace them with bog standard `if`/`elseif`/`else` syntax, instead.