### PR TITLE
Try to shut down more aggressively

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,9 +9,9 @@ Revision history for Perl extension PGXN::Manager
        - Added a logger to the Consumer and the Mastodon and Twitter handlers,
          so that they now log debug and info messages about what's being sent.
        - Moved PID file cleanup from the `DEMOLISH` method to the `run` method,
-         where it should always execute. This will hopefully fix the issue
-         where the consumer mysteriously ceases running and doesn't remove its
-         PID file, so never restarts.
+         and the signal handlers, where it should always execute at least once.
+         This will hopefully fix the issue where the consumer mysteriously
+         ceases running and doesn't remove its PID file, so never restarts.
        - Replaced use of the deprecated `given`/`when` syntax with plain old
          `if`/`elsif`/`else`.
 


### PR DESCRIPTION
Add a separate `shutdown` method called by `run` and by signal handlers. It's responsible for removing the PID file and for setting `continue` to `0`. This should ensure that it's always called at least once, and is safe to call multiple times. Either way the PID file should now always be deleted and the shutdown activity properly logged.

Also set all the signal handlers in the `_signal_handlers` method, and teach it to nest signal handlers if necessary. This will keep the consumer from wiping out its own handlers. I have no reason to think they have been, but it seems best to play it as safe as possible.

Add a slew of new tests to test all these behaviors thoroughly.