### PR TITLE
Add support for PostgreSQL 17-18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        pg: [16, 15, 14, 13, 12]
+        pg: [18, 17, 16, 15, 14, 13, 12]
     name: 🐘 PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools

--- a/Changes
+++ b/Changes
@@ -1,9 +1,12 @@
 Revision history for Perl extension PGXN::Manager
 
-0.32.2
+0.33.0  2025-11-29T20:45:07Z
       - Removed the `$libdir/` prefix from examples of the `module_pathname`
         control file parameter and from the `shared_preload_libraries`
         Postgres configuration variable.
+      - Reworked the database changes to be compatible with PostgreSQL and
+        later, and add change `20-into-json.sql` to re-run the relevant
+        scripts to upgrade an existing database ahead of upgrading PostgreSQL.
 
 0.32.1   2024-08-15T21:02:40Z
        - Added a TRACE log level to PGXN::Manager::Consumer.

--- a/bin/check_mirrors
+++ b/bin/check_mirrors
@@ -11,7 +11,7 @@ use File::Basename;
 use File::Spec;
 use Getopt::Long;
 
-BEGIN { our $VERSION = v0.32.2 }
+BEGIN { our $VERSION = v0.33.0 }
 
 Getopt::Long::Configure( qw(bundling) );
 

--- a/lib/PGXN/Manager.pm
+++ b/lib/PGXN/Manager.pm
@@ -19,7 +19,7 @@ use Email::Sender::Simple;
 use Encode;
 use namespace::autoclean;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 =head1 Name
 

--- a/lib/PGXN/Manager/Consumer.pm
+++ b/lib/PGXN/Manager/Consumer.pm
@@ -15,7 +15,7 @@ use IO::File;
 use Cwd;
 use namespace::autoclean;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 use constant CHANNELS => qw(release new_user new_mirror);
 
 has verbose  => (is => 'ro', isa => 'Int',  required => 1, default => 0);

--- a/lib/PGXN/Manager/Consumer/mastodon.pm
+++ b/lib/PGXN/Manager/Consumer/mastodon.pm
@@ -14,7 +14,7 @@ use warnings;
 use constant name => 'mastodon';
 use namespace::autoclean;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 has server  => (is => 'ro', required => 1, isa => 'Str');
 has ua      => (is => 'ro', required => 1, isa => 'LWP::UserAgent');

--- a/lib/PGXN/Manager/Consumer/twitter.pm
+++ b/lib/PGXN/Manager/Consumer/twitter.pm
@@ -12,7 +12,7 @@ use warnings;
 use constant name => 'twitter';
 use namespace::autoclean;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 subtype MaybeTwitterAPI => as maybe_type class_type 'Net::Twitter::Lite';
 

--- a/lib/PGXN/Manager/Controller.pm
+++ b/lib/PGXN/Manager/Controller.pm
@@ -18,7 +18,7 @@ use Try::Tiny;
 use SemVer;
 use namespace::autoclean;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 Template::Declare->init( dispatch_to => ['PGXN::Manager::Templates'] );
 

--- a/lib/PGXN/Manager/Distribution.pm
+++ b/lib/PGXN/Manager/Distribution.pm
@@ -19,7 +19,7 @@ use Digest::SHA1;
 use PGXN::Meta::Validator v0.12.0;
 use namespace::autoclean;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 my $TMPDIR = PGXN::Manager->new->config->{tmpdir}
           || File::Spec->catdir(File::Spec->tmpdir, 'pgxn');

--- a/lib/PGXN/Manager/Locale.pm
+++ b/lib/PGXN/Manager/Locale.pm
@@ -5,7 +5,7 @@ use utf8;
 use parent 'Locale::Maketext';
 use I18N::LangTags::Detect;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 # Allow unknown phrases to just pass-through.
 our %Lexicon = (

--- a/lib/PGXN/Manager/Locale/en.pm
+++ b/lib/PGXN/Manager/Locale/en.pm
@@ -4,7 +4,7 @@ use 5.10.0;
 use utf8;
 use parent 'PGXN::Manager::Locale';
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 our %Lexicon = (
 );

--- a/lib/PGXN/Manager/Locale/fr.pm
+++ b/lib/PGXN/Manager/Locale/fr.pm
@@ -4,7 +4,7 @@ use 5.10.0;
 use utf8;
 use parent 'PGXN::Manager::Locale';
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 our %Lexicon = (
     listcomma => ',',

--- a/lib/PGXN/Manager/Maint.pm
+++ b/lib/PGXN/Manager/Maint.pm
@@ -10,7 +10,7 @@ use File::Basename qw(dirname basename);
 use Encode qw(encode_utf8);
 use namespace::autoclean;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 has verbosity => (is => 'rw', required => 1, isa => 'Int', default => 0);
 has exitval   => (is => 'rw', required => 0, isa => 'Int', default => 0);

--- a/lib/PGXN/Manager/Request.pm
+++ b/lib/PGXN/Manager/Request.pm
@@ -10,7 +10,7 @@ use HTTP::Body 1.08; # required for proper upload mime type detection.
 use namespace::autoclean;
 use Encode;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 my $CHECK = Encode::FB_CROAK | Encode::LEAVE_SRC;
 my $SCRIPT_NAME = PGXN::Manager->config->{uri_script_name_key} || 'SCRIPT_NAME';

--- a/lib/PGXN/Manager/Router.pm
+++ b/lib/PGXN/Manager/Router.pm
@@ -9,7 +9,7 @@ use Plack::Session::Store::File;
 use PGXN::Manager::Controller;
 use PGXN::Manager;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 sub app {
     builder {

--- a/lib/PGXN/Manager/Templates.pm
+++ b/lib/PGXN/Manager/Templates.pm
@@ -7,7 +7,7 @@ use Template::Declare::Tags;
 use PGXN::Manager;
 use PGXN::Manager::Locale;
 
-our $VERSION = v0.32.2;
+our $VERSION = v0.33.0;
 
 my $l = PGXN::Manager::Locale->get_handle('en');
 sub T {

--- a/sql/07-json.sql
+++ b/sql/07-json.sql
@@ -25,17 +25,17 @@ returns the string. The difference is that `NULL` is treated as illegal
     JSON::XS->new->utf8(0)->allow_nonref->encode(shift);
 $$;
 
-CREATE OR REPLACE FUNCTION json_value(
+CREATE OR REPLACE FUNCTION into_json(
     val TEXT,
     def TEXT DEFAULT 'null'
 ) RETURNS TEXT LANGUAGE plperl IMMUTABLE AS $$
 =begin markdown
 
-    % SELECT json_value('foo'), json_value(NULL), json_value(NULL, 'default'),
-             json_value(NULL, NULL);
-     json_value │ json_value │ json_value │ json_value 
-    ────────────┼────────────┼────────────┼────────────
-     "foo"      │ null       │ default    │ 
+    % SELECT into_json('foo'), into_json(NULL), into_json(NULL, 'default'),
+             into_json(NULL, NULL);
+     into_json │ into_json │ into_json │ into_json 
+    ───────────┼───────────┼───────────┼───────────
+     "foo"     │ null      │ default   │ 
 
 Encodes a text value as a JSON string. If the string is `NULL`, the second
 argument will be used as a fallback. If there is no second argument, it will
@@ -47,17 +47,17 @@ fall back to "null".
     defined $_[0] ? JSON::XS->new->utf8(0)->allow_nonref->encode($_[0]) : $_[1];
 $$;
 
-CREATE OR REPLACE FUNCTION json_value(
+CREATE OR REPLACE FUNCTION into_json(
     val numeric,
     def TEXT DEFAULT 'null'
 ) RETURNS TEXT LANGUAGE SQL IMMUTABLE AS $$
 /*
 
-    % SELECT json_value(1.2), json_value(NULL::int),
-             json_value(NULL::int, 'default'), json_value(NULL::int, NULL);
-     json_value │ json_value │ json_value │ json_value 
-    ────────────┼────────────┼────────────┼────────────
-     1.2        │ null       │ default    │ 
+    % SELECT into_json(1.2), into_json(NULL::int),
+             into_json(NULL::int, 'default'), into_json(NULL::int, NULL);
+     into_json │ into_json │ into_json │ into_json 
+    ───────────┼───────────┼───────────┼───────────
+     1.2       │ null      │ default   │ 
 
 Encodes a numeric value as a JSON number. If the number is `NULL`, the second
 argument will be used as a fallback. If there is no second argument, it will
@@ -67,17 +67,17 @@ fall back to "null".
     SELECT COALESCE($1::text, $2);
 $$;
 
-CREATE OR REPLACE FUNCTION json_value(
+CREATE OR REPLACE FUNCTION into_json(
     val BOOLEAN,
     def TEXT DEFAULT 'null'
 ) RETURNS TEXT LANGUAGE SQL IMMUTABLE AS $$
 /*
 
-    % SELECT json_value(TRUE), json_value(NULL::bool),
-             json_value(NULL::bool, 'default'), json_value(NULL::bool, NULL);
-     json_value │ json_value │ json_value │ json_value 
-    ────────────┼────────────┼────────────┼────────────
-     true       │ null       │ default    │ [null]
+    % SELECT into_json(TRUE), into_json(NULL::bool),
+             into_json(NULL::bool, 'default'), into_json(NULL::bool, NULL);
+     into_json │ into_json │ into_json │ into_json 
+    ───────────┼───────────┼───────────┼───────────
+     true      │ null      │ default   │ [null]
 
 Encodes a boolean value as a JSON boolean ("true" or "false"). If the boolean
 is `NULL`, the second argument will be used as a fallback. If there is no

--- a/sql/10-json_data.sql
+++ b/sql/10-json_data.sql
@@ -63,16 +63,16 @@ objects. All the required fields will be present, and the optional fields
 */
     SELECT E'[\n   ' || array_to_string(ARRAY(
         SELECT E'{\n      ' || array_to_string(ARRAY[
-            json_key('uri')          || ': ' || json_value(uri),
-            json_key('frequency')    || ': ' || json_value(frequency),
-            json_key('location')     || ': ' || json_value(location),
-            json_key('organization') || ': ' || json_value(organization),
-            json_key('timezone')     || ': ' || json_value(timezone),
-            json_key('email')        || ': ' || json_value(munge_email(email)),
-            json_key('bandwidth')    || ': ' || json_value(bandwidth),
-            json_key('src')          || ': ' || json_value(src),
-            json_key('rsync')        || ': ' || json_value(rsync, NULL),
-            json_key('notes')        || ': ' || json_value(notes, NULL)
+            json_key('uri')          || ': ' || into_json(uri),
+            json_key('frequency')    || ': ' || into_json(frequency),
+            json_key('location')     || ': ' || into_json(location),
+            json_key('organization') || ': ' || into_json(organization),
+            json_key('timezone')     || ': ' || into_json(timezone),
+            json_key('email')        || ': ' || into_json(munge_email(email)),
+            json_key('bandwidth')    || ': ' || into_json(bandwidth),
+            json_key('src')          || ': ' || into_json(src),
+            json_key('rsync')        || ': ' || into_json(rsync, NULL),
+            json_key('notes')        || ': ' || into_json(notes, NULL)
         ], E',\n      '
         ) || E'\n   }' FROM mirrors
          ORDER BY created_at
@@ -84,7 +84,7 @@ CREATE OR REPLACE FUNCTION extension_json(
    version   SEMVER
 ) RETURNS TABLE (
     extension TERM,
-    json      TEXT
+    "json"    TEXT
 ) LANGUAGE plpgsql STABLE STRICT AS $$
 /*
 
@@ -171,8 +171,8 @@ BEGIN
     LOOP
         IF (prev IS NOT NULL AND prev <> LOWER(ext)) OR ext IS NULL THEN
             extension := LOWER(prev);
-            json := E'{\n   "extension": ' || json_value(prev)
-                 || E',\n   "latest": ' || json_value(latest)
+            json := E'{\n   "extension": ' || into_json(prev)
+                 || E',\n   "latest": ' || into_json(latest)
                  || COALESCE(E',\n   "stable":'   || stable, '')
                  || COALESCE(E',\n   "testing":'  || testing, '')
                  || COALESCE(E',\n   "unstable":' || unstable, '')
@@ -192,29 +192,29 @@ BEGIN
         BEGIN
             FOR dist IN SELECT * FROM unnest(dists) LOOP
                 myjson := array_append(myjson,
-                          '         { "dist": ' || json_value(dist->'dist')
-                       || ', "version": ' || json_value(dist->'version')
+                          '         { "dist": ' || into_json(dist->'dist')
+                       || ', "version": ' || into_json(dist->'version')
                        || CASE dist->'relstatus'
                               WHEN 'stable' THEN ''
-                              ELSE ', "status": ' || json_value(dist->'relstatus')
+                              ELSE ', "status": ' || into_json(dist->'relstatus')
                           END
                        || E' }');
                 IF latest IS NULL THEN latest := dist->'relstatus'; END IF;
                 CASE dist->'relstatus'
                     WHEN 'stable' THEN IF stable IS NULL THEN
-                        stable := ' { "dist": ' || json_value(dist->'dist')
-                        || ', "version": ' || json_value(dist->'version')
-                        || ', "sha1": ' || json_value(dist->'sha1') || ' }';
+                        stable := ' { "dist": ' || into_json(dist->'dist')
+                        || ', "version": ' || into_json(dist->'version')
+                        || ', "sha1": ' || into_json(dist->'sha1') || ' }';
                     END IF;
                     WHEN 'testing' THEN IF testing IS NULL THEN
-                        testing := ' { "dist": ' || json_value(dist->'dist')
-                        || ', "version": ' || json_value(dist->'version')
-                        || ', "sha1": ' || json_value(dist->'sha1') || ' }';
+                        testing := ' { "dist": ' || into_json(dist->'dist')
+                        || ', "version": ' || into_json(dist->'version')
+                        || ', "sha1": ' || into_json(dist->'sha1') || ' }';
                     END IF;
                     WHEN 'unstable' THEN IF unstable IS NULL THEN
-                        unstable := ' { "dist": ' || json_value(dist->'dist')
-                        || ', "version": ' || json_value(dist->'version')
-                        || ', "sha1": ' || json_value(dist->'sha1') || ' }';
+                        unstable := ' { "dist": ' || into_json(dist->'dist')
+                        || ', "version": ' || into_json(dist->'version')
+                        || ', "sha1": ' || into_json(dist->'sha1') || ' }';
                     END IF;
                 END CASE;
             END LOOP;
@@ -266,7 +266,7 @@ Returns a JSON string describing a distribution, including all of its released
 versions and their dates.
 
 */
-    SELECT E'{\n   "name": ' || json_value($1)
+    SELECT E'{\n   "name": ' || into_json($1)
            || E',\n   "releases": {\n      '
            || array_to_string(ARRAY[
                '"stable": '   || stable,
@@ -305,8 +305,8 @@ CREATE OR REPLACE FUNCTION tag_json(
    dist      TERM,
    version   SEMVER
 ) RETURNS TABLE (
-    tag  TAG,
-    json TEXT
+    tag    TAG,
+    "json" TEXT
 ) LANGUAGE sql STABLE STRICT AS $$
 /*
 
@@ -384,7 +384,7 @@ well.
           FROM ds
          GROUP BY tag, distribution
     )
-    SELECT LOWER(tag)::tag, E'{\n   "tag": ' || json_value(tag) || E',\n   "releases": {\n      '
+    SELECT LOWER(tag)::tag, E'{\n   "tag": ' || into_json(tag) || E',\n   "releases": {\n      '
         || string_agg(json_key(distribution) || E': {\n         '
         || array_to_string(relv, E',\n         '), E'\n      },\n      ')
         || E'\n      }\n   }\n}\n'
@@ -454,11 +454,11 @@ user and thus not included in the JSON.
         GROUP BY name, creator
     )
     SELECT E'{\n   ' || array_to_string(ARRAY[
-        '"nickname": ' || json_value(u.nickname),
-        '"name": '     || json_value(u.full_name),
-        '"email": '    || json_value(u.email),
-        '"uri": '      || json_value(CASE uri WHEN '' THEN NULL ELSE uri END, NULL),
-        '"twitter": '  || json_value(CASE u.twitter WHEN '' THEN NULL ELSE u.twitter END, NULL)
+        '"nickname": ' || into_json(u.nickname),
+        '"name": '     || into_json(u.full_name),
+        '"email": '    || into_json(u.email),
+        '"uri": '      || into_json(CASE uri WHEN '' THEN NULL ELSE uri END, NULL),
+        '"twitter": '  || into_json(CASE u.twitter WHEN '' THEN NULL ELSE u.twitter END, NULL)
     ], E',\n   ') || COALESCE(E',\n   "releases": {\n' ||
            string_agg(
                  '      "' || dv.distribution
@@ -505,7 +505,7 @@ appear in the popular list. The default limit is 56.
 */
     SELECT E'{\n   "count": ' || COUNT(DISTINCT tag) || E',\n   "popular": [\n'
         || array_to_string(ARRAY(
-        SELECT '      {"tag": ' || json_value(tag)
+        SELECT '      {"tag": ' || into_json(tag)
             || ', "dists": ' || COUNT(DISTINCT distribution) || E'}'
           FROM distribution_tags
          GROUP BY tag
@@ -545,8 +545,8 @@ appear in the prolific list. The default limit is 56.
 */
     SELECT E'{\n   "count": ' || COUNT(*) || E',\n   "prolific": [\n'
         || array_to_string(ARRAY(
-        SELECT '      {"nickname": ' || json_value(u.nickname)
-            || ', "name": '     || json_value(u.full_name)
+        SELECT '      {"nickname": ' || into_json(u.nickname)
+            || ', "name": '     || into_json(u.full_name)
             || ', "dists": '    || COUNT(DISTINCT d.name)
             || ', "releases": ' || COUNT(d.name) || E'}'
           FROM users u
@@ -613,14 +613,14 @@ that appear in the recent list. The default limit is 56.
     SELECT E'{\n   "count": ' || COUNT(*) || E',\n   "recent": [\n'
         || array_to_string(ARRAY(
         SELECT E'      {\n'
-            || '         "extension": '   || json_value(de.extension) || E',\n'
-            || '         "abstract": '    || json_value(de.abstract) || E',\n'
-            || '         "ext_version": ' || json_value(de.ext_version::text) || E',\n'
-            || '         "dist": '        || json_value(d.name) || E',\n'
-            || '         "version": '     || json_value(d.version::text) || E',\n'
-            || '         "date": '        || json_value(utc_date(d.created_at)) || E',\n'
-            || '         "user": '        || json_value(d.creator) || E',\n'
-            || '         "user_name": '   || json_value(u.full_name)
+            || '         "extension": '   || into_json(de.extension) || E',\n'
+            || '         "abstract": '    || into_json(de.abstract) || E',\n'
+            || '         "ext_version": ' || into_json(de.ext_version::text) || E',\n'
+            || '         "dist": '        || into_json(d.name) || E',\n'
+            || '         "version": '     || into_json(d.version::text) || E',\n'
+            || '         "date": '        || into_json(utc_date(d.created_at)) || E',\n'
+            || '         "user": '        || into_json(d.creator) || E',\n'
+            || '         "user_name": '   || into_json(u.full_name)
             || E'\n      }'
           FROM distributions d
           JOIN distribution_extensions de
@@ -688,12 +688,12 @@ distributions that appear in the recent list. The default limit is 56.
         || E',\n   "releases": ' || COUNT(*) || E',\n   "recent": [\n'
         || array_to_string(ARRAY(
         SELECT E'      {\n'
-            || '         "dist": '      || json_value(d.name) || E',\n'
-            || '         "version": '   || json_value(d.version::text) || E',\n'
-            || '         "abstract": '  || json_value(d.abstract) || E',\n'
-            || '         "date": '      || json_value(utc_date(d.created_at)) || E',\n'
-            || '         "user": '      || json_value(d.creator) || E',\n'
-            || '         "user_name": ' || json_value(u.full_name)
+            || '         "dist": '      || into_json(d.name) || E',\n'
+            || '         "version": '   || into_json(d.version::text) || E',\n'
+            || '         "abstract": '  || into_json(d.abstract) || E',\n'
+            || '         "date": '      || into_json(utc_date(d.created_at)) || E',\n'
+            || '         "user": '      || into_json(d.creator) || E',\n'
+            || '         "user_name": ' || into_json(u.full_name)
             || E'\n      }'
           FROM distributions d
           JOIN users u ON d.creator = u.nickname
@@ -746,7 +746,7 @@ CREATE OR REPLACE FUNCTION all_stats_json(
     num_to_list INT DEFAULT 56
 ) RETURNS TABLE (
     stats_name TEXT,
-    json       TEXT
+    "json"     TEXT
 ) LANGUAGE sql STABLE STRICT SECURITY DEFINER AS $$
 /*
 

--- a/sql/11-dist_management.sql
+++ b/sql/11-dist_management.sql
@@ -3,7 +3,7 @@
 CREATE OR REPLACE FUNCTION setup_meta(
     IN  nick        LABEL,
     IN  sha1        TEXT,
-    IN  json        TEXT,
+    IN  "json"      TEXT,
     OUT name        TERM,
     OUT version     SEMVER,
     OUT relstatus   RELSTATUS,
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION setup_meta(
     OUT description TEXT,
     OUT provided    TEXT[][],
     OUT tags        CITEXT[],
-    OUT json        TEXT
+    OUT "json"      TEXT
 ) LANGUAGE plperl IMMUTABLE AS $$
     my ($user, $sha1) = (shift, shift);
     my $meta = JSON::XS->new->utf8(0)->decode(shift);
@@ -125,7 +125,7 @@ CREATE OR REPLACE FUNCTION get_distribution(
 ) RETURNS TABLE (
     template TEXT,
     subject  TEXT,
-    json     TEXT
+    "json"   TEXT
 ) LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER AS $$
 /*
 

--- a/sql/15-dist_processing.sql
+++ b/sql/15-dist_processing.sql
@@ -87,7 +87,7 @@ CREATE OR REPLACE FUNCTION add_distribution(
 ) RETURNS TABLE (
     template TEXT,
     subject  TEXT,
-    json     TEXT
+    "json"   TEXT
 ) LANGUAGE plpgsql STRICT SECURITY DEFINER AS $$
 /*
 
@@ -409,7 +409,7 @@ CREATE OR REPLACE FUNCTION update_distribution(
 ) RETURNS TABLE (
     template TEXT,
     subject  TEXT,
-    json     TEXT
+    "json"   TEXT
 ) LANGUAGE plpgsql STRICT SECURITY DEFINER AS $$
 /*
 

--- a/sql/19-tag-stats-json.sql
+++ b/sql/19-tag-stats-json.sql
@@ -37,7 +37,7 @@ appear in the popular list. The default limit is 56.
 */
     SELECT E'{\n   "count": ' || COUNT(DISTINCT tag) || E',\n   "popular": [\n'
         || array_to_string(ARRAY(
-        SELECT '      {"tag": ' || json_value(LOWER(tag))
+        SELECT '      {"tag": ' || into_json(LOWER(tag))
             || ', "dists": ' || COUNT(DISTINCT distribution) || E'}'
           FROM distribution_tags
          GROUP BY tag

--- a/sql/20-into-json.sql
+++ b/sql/20-into-json.sql
@@ -1,0 +1,9 @@
+-- PostgreSQL 17 added json_value() and made "json" a reserved word. The
+-- following scripts were updated to be compatible; we re-run them here to
+-- update existing databases.
+
+\i sql/07-json.sql
+\i sql/10-json_data.sql
+\i sql/11-dist_management.sql
+\i sql/15-dist_processing.sql
+\i sql/19-tag-stats-json.sql

--- a/t/json.pg
+++ b/t/json.pg
@@ -24,65 +24,65 @@ SELECT throws_like(
 );
 
 /****************************************************************************/
--- Test json_value(text).
+-- Test into_json(text).
 
-SELECT has_function(    'json_value' );
-SELECT has_function(    'json_value', ARRAY['text', 'text'] );
-SELECT function_returns('json_value', ARRAY['text', 'text'], 'text' );
-SELECT function_lang_is('json_value', ARRAY['text', 'text'], 'plperl' );
-SELECT volatility_is(   'json_value', ARRAY['text', 'text'], 'immutable' );
+SELECT has_function(    'into_json' );
+SELECT has_function(    'into_json', ARRAY['text', 'text'] );
+SELECT function_returns('into_json', ARRAY['text', 'text'], 'text' );
+SELECT function_lang_is('into_json', ARRAY['text', 'text'], 'plperl' );
+SELECT volatility_is(   'into_json', ARRAY['text', 'text'], 'immutable' );
 SELECT ok(
-    has_function_privilege('pgxn', 'json_value(text, text)', 'EXECUTE'),
-    'User "pgxn" should have EXECUTE priv on json_value()'
+    has_function_privilege('pgxn', 'into_json(text, text)', 'EXECUTE'),
+    'User "pgxn" should have EXECUTE priv on into_json()'
 );
 
-SELECT is( json_value('foo'), '"foo"', 'json_value(foo)' );
-SELECT is( json_value(E'fo\no'), E'"fo\\no"', E'json_value(fo\\no)' );
-SELECT is( json_value('http://foo.com'::uri), '"http://foo.com"', 'json_value(uri)' );
-SELECT is( json_value('foo', 'bar'), '"foo"', 'json_value(text, text)');
-SELECT is( json_value(NULL::text), 'null', 'json_value(NULL::text)');
-SELECT is( json_value(NULL::text, 'foo'), 'foo', 'json_value(NULL::text, text)');
-SELECT is( json_value(NULL::text, NULL::text), NULL, 'json_value(NULL::text, NULL::text)');
+SELECT is( into_json('foo'), '"foo"', 'into_json(foo)' );
+SELECT is( into_json(E'fo\no'), E'"fo\\no"', E'into_json(fo\\no)' );
+SELECT is( into_json('http://foo.com'::uri), '"http://foo.com"', 'into_json(uri)' );
+SELECT is( into_json('foo', 'bar'), '"foo"', 'into_json(text, text)');
+SELECT is( into_json(NULL::text), 'null', 'into_json(NULL::text)');
+SELECT is( into_json(NULL::text, 'foo'), 'foo', 'into_json(NULL::text, text)');
+SELECT is( into_json(NULL::text, NULL::text), NULL, 'into_json(NULL::text, NULL::text)');
 
 /****************************************************************************/
--- Test json_value(numeric).
+-- Test into_json(numeric).
 
-SELECT has_function(    'json_value' );
-SELECT has_function(    'json_value', ARRAY['numeric', 'text'] );
-SELECT function_returns('json_value', ARRAY['numeric', 'text'], 'text' );
-SELECT function_lang_is('json_value', ARRAY['numeric', 'text'], 'sql' );
-SELECT volatility_is(   'json_value', ARRAY['numeric', 'text'], 'immutable' );
+SELECT has_function(    'into_json' );
+SELECT has_function(    'into_json', ARRAY['numeric', 'text'] );
+SELECT function_returns('into_json', ARRAY['numeric', 'text'], 'text' );
+SELECT function_lang_is('into_json', ARRAY['numeric', 'text'], 'sql' );
+SELECT volatility_is(   'into_json', ARRAY['numeric', 'text'], 'immutable' );
 SELECT ok(
-    has_function_privilege('pgxn', 'json_value(numeric, text)', 'EXECUTE'),
-    'User "pgxn" should have EXECUTE priv on json_value()'
+    has_function_privilege('pgxn', 'into_json(numeric, text)', 'EXECUTE'),
+    'User "pgxn" should have EXECUTE priv on into_json()'
 );
 
-SELECT is( json_value(1), '1', 'json_value(1)' );
-SELECT is( json_value(1.2), '1.2', 'json_value(1.2)' );
-SELECT is( json_value(1::bigint), '1', 'json_value(1::bigint)' );
-SELECT is( json_value(NULL::int), 'null', 'json_value(NULL::int)');
-SELECT is( json_value(NULL::int, 'foo'), 'foo', 'json_value(NULL::int, text)');
-SELECT is( json_value(NULL::int, NULL::text), NULL, 'json_value(NULL::int, NULL::text)');
+SELECT is( into_json(1), '1', 'into_json(1)' );
+SELECT is( into_json(1.2), '1.2', 'into_json(1.2)' );
+SELECT is( into_json(1::bigint), '1', 'into_json(1::bigint)' );
+SELECT is( into_json(NULL::int), 'null', 'into_json(NULL::int)');
+SELECT is( into_json(NULL::int, 'foo'), 'foo', 'into_json(NULL::int, text)');
+SELECT is( into_json(NULL::int, NULL::text), NULL, 'into_json(NULL::int, NULL::text)');
 
 /****************************************************************************/
--- Test json_value(boolean).
+-- Test into_json(boolean).
 
-SELECT has_function(    'json_value' );
-SELECT has_function(    'json_value', ARRAY['boolean', 'text'] );
-SELECT function_returns('json_value', ARRAY['boolean', 'text'], 'text' );
-SELECT function_lang_is('json_value', ARRAY['boolean', 'text'], 'sql' );
-SELECT volatility_is(   'json_value', ARRAY['boolean', 'text'], 'immutable' );
+SELECT has_function(    'into_json' );
+SELECT has_function(    'into_json', ARRAY['boolean', 'text'] );
+SELECT function_returns('into_json', ARRAY['boolean', 'text'], 'text' );
+SELECT function_lang_is('into_json', ARRAY['boolean', 'text'], 'sql' );
+SELECT volatility_is(   'into_json', ARRAY['boolean', 'text'], 'immutable' );
 SELECT ok(
-    has_function_privilege('pgxn', 'json_value(boolean, text)', 'EXECUTE'),
-    'User "pgxn" should have EXECUTE priv on json_value()'
+    has_function_privilege('pgxn', 'into_json(boolean, text)', 'EXECUTE'),
+    'User "pgxn" should have EXECUTE priv on into_json()'
 );
 
-SELECT is( json_value(true), 'true', 'json_value(true)' );
-SELECT is( json_value(false), 'false', 'json_value(false)' );
-SELECT is( json_value(NULL::bool), 'null', 'json_value(NULL)' );
-SELECT is( json_value(NULL::bool), 'null', 'json_value(NULL::bool)');
-SELECT is( json_value(NULL::bool, 'foo'), 'foo', 'json_value(NULL::bool, text)');
-SELECT is( json_value(NULL::bool, NULL::text), NULL, 'json_value(NULL::bool, NULL::text)');
+SELECT is( into_json(true), 'true', 'into_json(true)' );
+SELECT is( into_json(false), 'false', 'into_json(false)' );
+SELECT is( into_json(NULL::bool), 'null', 'into_json(NULL)' );
+SELECT is( into_json(NULL::bool), 'null', 'into_json(NULL::bool)');
+SELECT is( into_json(NULL::bool, 'foo'), 'foo', 'into_json(NULL::bool, text)');
+SELECT is( into_json(NULL::bool, NULL::text), NULL, 'into_json(NULL::bool, NULL::text)');
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/t/json_data.pg
+++ b/t/json_data.pg
@@ -5,8 +5,8 @@ SELECT plan(164);
 /****************************************************************************/
 -- Assertion function for validating JSON.
 CREATE OR REPLACE FUNCTION json_ok(
-    json  TEXT,
-    descr TEXT
+    "json" TEXT,
+    descr  TEXT
 ) RETURNS TEXT LANGUAGE plperl AS $$
     eval { JSON::XS->new->decode(shift) };
     my $ok = sub {

--- a/t/mastodon.t
+++ b/t/mastodon.t
@@ -10,6 +10,7 @@ use Test::More tests => 41;
 use JSON::XS;
 use Test::Exception;
 use Test::MockModule;
+use POSIX ();
 use lib 't/lib';
 use TxnTest;
 


### PR DESCRIPTION
PostgreSQL 17 added json_value() and made "json" a reserved word. So update the relevant SQL scripts and tests to rename `json_value()` to `into_json()` and to quote `"json"` when used as a function parameter or return table column name. Add `sql/20-into-sql` to simply re-execute those files, so that an existing database will be updated ahead of upgrading to PostgreSQL 17 or later.

Also:

*   Add PostgreSQL 17 and 18 to the CI test workflow
*   Explicitly load `POSIX` in `t/mastodon.t`
*   Increment to v0.33.0 and timestamp for release