### PR TITLE
Add `21-cleanup-json.sql` and pg 17 upgrade notes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension PGXN::Manager
 
+0.33.1 2025-11-29T22:22:43Z
+     - Added `sql/21-cleanup-json.sql` to remove deleted functions from
+       PostgreSQL 16 or earlier.
+     - Added notes for upgrading to PostgreSQL 17+ to the README.
+
 0.33.0  2025-11-29T20:45:07Z
       - Removed the `$libdir/` prefix from examples of the `module_pathname`
         control file parameter and from the `shared_preload_libraries`

--- a/README.md
+++ b/README.md
@@ -156,6 +156,25 @@ Installation
 
 *   Profit!
 
+Upgrading to PostgreSQL 17
+--------------------------
+
+PostgreSQL 17 added `json_value()` and made `json` a reserved word,
+conflicting with the PGXN::Manager database schema prior to v0.33.1.
+For an existing database, to upgrade to PostgreSQL 17 or later, follow these
+steps:
+
+1.  Upgrade to PGXN::Manager v0.33.1 and run `./Build db` to upgrade the
+    database. `SELECT value FROM metadata WHERE label = 'schema_version'`
+    should return 21.
+2.  Dump the database with the `--quote-all-identifiers` option to `pg_dump`.
+3.  Load the PostgreSQL 17+ database from the dump file.
+
+The upgrade requires these steps because otherwise the term `json` is not
+properly quoted as `"json"` in PostgreSQL 16, so the upgrade will fail. Thus
+the database must be dumped with full quoting and then loaded from the dump
+file.
+
 Running a Proxy Server
 ----------------------
 

--- a/bin/check_mirrors
+++ b/bin/check_mirrors
@@ -11,7 +11,7 @@ use File::Basename;
 use File::Spec;
 use Getopt::Long;
 
-BEGIN { our $VERSION = v0.33.0 }
+BEGIN { our $VERSION = v0.33.1 }
 
 Getopt::Long::Configure( qw(bundling) );
 

--- a/lib/PGXN/Manager.pm
+++ b/lib/PGXN/Manager.pm
@@ -19,7 +19,7 @@ use Email::Sender::Simple;
 use Encode;
 use namespace::autoclean;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 =head1 Name
 

--- a/lib/PGXN/Manager/Consumer.pm
+++ b/lib/PGXN/Manager/Consumer.pm
@@ -15,7 +15,7 @@ use IO::File;
 use Cwd;
 use namespace::autoclean;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 use constant CHANNELS => qw(release new_user new_mirror);
 
 has verbose  => (is => 'ro', isa => 'Int',  required => 1, default => 0);

--- a/lib/PGXN/Manager/Consumer/mastodon.pm
+++ b/lib/PGXN/Manager/Consumer/mastodon.pm
@@ -14,7 +14,7 @@ use warnings;
 use constant name => 'mastodon';
 use namespace::autoclean;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 has server  => (is => 'ro', required => 1, isa => 'Str');
 has ua      => (is => 'ro', required => 1, isa => 'LWP::UserAgent');

--- a/lib/PGXN/Manager/Consumer/twitter.pm
+++ b/lib/PGXN/Manager/Consumer/twitter.pm
@@ -12,7 +12,7 @@ use warnings;
 use constant name => 'twitter';
 use namespace::autoclean;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 subtype MaybeTwitterAPI => as maybe_type class_type 'Net::Twitter::Lite';
 

--- a/lib/PGXN/Manager/Controller.pm
+++ b/lib/PGXN/Manager/Controller.pm
@@ -18,7 +18,7 @@ use Try::Tiny;
 use SemVer;
 use namespace::autoclean;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 Template::Declare->init( dispatch_to => ['PGXN::Manager::Templates'] );
 

--- a/lib/PGXN/Manager/Distribution.pm
+++ b/lib/PGXN/Manager/Distribution.pm
@@ -19,7 +19,7 @@ use Digest::SHA1;
 use PGXN::Meta::Validator v0.12.0;
 use namespace::autoclean;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 my $TMPDIR = PGXN::Manager->new->config->{tmpdir}
           || File::Spec->catdir(File::Spec->tmpdir, 'pgxn');

--- a/lib/PGXN/Manager/Locale.pm
+++ b/lib/PGXN/Manager/Locale.pm
@@ -5,7 +5,7 @@ use utf8;
 use parent 'Locale::Maketext';
 use I18N::LangTags::Detect;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 # Allow unknown phrases to just pass-through.
 our %Lexicon = (

--- a/lib/PGXN/Manager/Locale/en.pm
+++ b/lib/PGXN/Manager/Locale/en.pm
@@ -4,7 +4,7 @@ use 5.10.0;
 use utf8;
 use parent 'PGXN::Manager::Locale';
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 our %Lexicon = (
 );

--- a/lib/PGXN/Manager/Locale/fr.pm
+++ b/lib/PGXN/Manager/Locale/fr.pm
@@ -4,7 +4,7 @@ use 5.10.0;
 use utf8;
 use parent 'PGXN::Manager::Locale';
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 our %Lexicon = (
     listcomma => ',',

--- a/lib/PGXN/Manager/Maint.pm
+++ b/lib/PGXN/Manager/Maint.pm
@@ -10,7 +10,7 @@ use File::Basename qw(dirname basename);
 use Encode qw(encode_utf8);
 use namespace::autoclean;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 has verbosity => (is => 'rw', required => 1, isa => 'Int', default => 0);
 has exitval   => (is => 'rw', required => 0, isa => 'Int', default => 0);

--- a/lib/PGXN/Manager/Request.pm
+++ b/lib/PGXN/Manager/Request.pm
@@ -10,7 +10,7 @@ use HTTP::Body 1.08; # required for proper upload mime type detection.
 use namespace::autoclean;
 use Encode;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 my $CHECK = Encode::FB_CROAK | Encode::LEAVE_SRC;
 my $SCRIPT_NAME = PGXN::Manager->config->{uri_script_name_key} || 'SCRIPT_NAME';

--- a/lib/PGXN/Manager/Router.pm
+++ b/lib/PGXN/Manager/Router.pm
@@ -9,7 +9,7 @@ use Plack::Session::Store::File;
 use PGXN::Manager::Controller;
 use PGXN::Manager;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 sub app {
     builder {

--- a/lib/PGXN/Manager/Templates.pm
+++ b/lib/PGXN/Manager/Templates.pm
@@ -7,7 +7,7 @@ use Template::Declare::Tags;
 use PGXN::Manager;
 use PGXN::Manager::Locale;
 
-our $VERSION = v0.33.0;
+our $VERSION = v0.33.1;
 
 my $l = PGXN::Manager::Locale->get_handle('en');
 sub T {

--- a/sql/21-cleanup-json.sql
+++ b/sql/21-cleanup-json.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+SET client_min_messages TO warning;
+
+-- Drop replaced functions.
+DO LANGUAGE PLpgSQL $$
+BEGIN
+    IF current_setting('server_version_num')::int < 170000 THEN
+        EXECUTE $_$
+            DROP FUNCTION IF EXISTS json_value(TEXT, TEXT);
+            DROP FUNCTION IF EXISTS json_value(NUMERIC, TEXT);
+            DROP FUNCTION IF EXISTS json_value(BOOLEAN, TEXT);
+        $_$;
+    END IF;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
Add a new migration, `sql/21-cleanup-json.sql`, that drops the old `json_value` function that was renamed in `sql/20-into-json.sql`.

Add the "Upgrading to PostgreSQL 17" section to the README to note that the database must be dumped with the `--quote-all-identifiers` option to `pg_dump` in order to compatibly migrate to PostgreSQL 17.

Increment to and timestamp v0.33.1.